### PR TITLE
Add doc comments and copyright statements

### DIFF
--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -25,6 +25,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Load messages from an array.
+ *
+ * @copyright © 2014 Bryan Davis and Wikimedia Foundation
  */
 class ArrayCache implements MessageCache {
 

--- a/src/I18nContext.php
+++ b/src/I18nContext.php
@@ -24,7 +24,7 @@ namespace Wikimedia\SimpleI18n;
 use Psr\Log\LoggerInterface;
 
 /**
- * Holds and optionally detects langauge for current request. Also serves as
+ * Holds and optionally detects language for current request. Also serves as
  * a factory for creating Message objects which can be used to subsitute
  * localized message content based on the current language.
  *

--- a/src/JsonCache.php
+++ b/src/JsonCache.php
@@ -25,6 +25,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Load messages from JSON files in a given directory.
+ *
+ * @copyright © 2014 Bryan Davis and Wikimedia Foundation
  */
 class JsonCache extends ArrayCache {
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -24,7 +24,13 @@ namespace Wikimedia\SimpleI18n;
 use Psr\Log\LoggerInterface;
 
 /**
- * Interface message.
+ * Localizable message.
+ *
+ * This class can be used to look up a localized message based on a given key
+ * and the active I18nContext language and convert it to a plain or escaped
+ * string.
+ *
+ * @copyright © 2014 Wikimedia Foundation
  */
 class Message {
 
@@ -93,7 +99,7 @@ class Message {
 	/**
 	 * Add parameters to the paramter list of this message.
 	 *
-	 * @param mixed $params,... Parameters as strings of a single argument that
+	 * @param mixed $params,... Parameters as strings or a single argument that
 	 * is an array of strings.
 	 *
 	 * @return Message Self

--- a/src/MessageCache.php
+++ b/src/MessageCache.php
@@ -23,6 +23,8 @@ namespace Wikimedia\SimpleI18n;
 
 /**
  * Container for localized messages.
+ *
+ * @copyright © 2014 Bryan Davis and Wikimedia Foundation
  */
 interface MessageCache {
 

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -23,6 +23,21 @@ namespace Wikimedia\SimpleI18n;
 
 /**
  * Integrate SimpleI18n with the Twig template engine.
+ *
+ * Provides a `message` Twig filter that treats the modified variable as
+ * a Message key and returns the plain formatted value of that Message.
+ * Message parameters can be provided as either individual arguments to the
+ * filter or optionally as a single array of argument containing a list of
+ * parameters.
+ *
+ * <code>
+ * {{ 'my-message-key'|message }}
+ * {{ 'my-message-key'|message( 'foo', 'bar' ) }}
+ * {{ 'my-message-key'|message( [ 'foo', 'bar' ] ) }}
+ * {{ 'my-message-key'|message( 'foo', 'bar' )|raw }}
+ * </code>
+ *
+ * @copyright © 2014 Bryan Davis and Wikimedia Foundation
  */
 class TwigExtension extends \Twig_Extension {
 
@@ -75,6 +90,4 @@ class TwigExtension extends \Twig_Extension {
 		$msg = $this->ctx->message( $key, $params );
 		return $msg->plain();
 	}
-
-	// 'foo'|message(p1, p2, p3)
 }


### PR DESCRIPTION
- Add better documentation comments for Message and TwigExtension.
- Make sure all files contain a copyright statement declaring the
  Wikimedia Foundation a copyright holder.
