### PR TITLE
build: Simplify phpunit setup

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="tests/bootstrap.php" colors="true" strict="true" verbose="true">
+<phpunit bootstrap="tests/bootstrap.php" colors="true" strict="true">
     <testsuites>
         <testsuite name="SimpleI18n Test Suite">
-            <directory suffix="Test.php">./tests/</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
-
     <logging>
-        <log type="tap" target="php://stdout" logIncompleteSkipped="true"/>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
     </logging>
-
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,3 @@
 <?php
-$loader = require __DIR__ . '/../vendor/autoload.php';
-$loader->addPsr4('Wikimedia\\SimpleI18n\\', __DIR__);
+require __DIR__ . '/../vendor/autoload.php';
 date_default_timezone_set('UTC');


### PR DESCRIPTION
- PSR4 autoloader is already set up by composer.
- Remove verbose flag from phpunit (matching other projects,
  doesn't seem to do anything in phpunit by default anyway).
- Remove TAP output (thus displaying only failures).
